### PR TITLE
unescape html entities

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ const Twitter = require('twitter')
 const MarkovGen = require('markov-generator')
 const tipots = require('this-is-probably-ok-to-say')
 const schedule = require('node-schedule')
+const unescape = require('lodash.unescape')
 
 class TwitterBot {
 
@@ -117,8 +118,9 @@ class TwitterBot {
       this.twitterClient.get('statuses/user_timeline', {screen_name: this.options.account, max_id: max_id, count: 200, exclude_replies: true, include_rts: false}, (error, timeline, response) => {
         if (error) throw new Error(error[0].message)
         timeline.forEach((e, i, a) => {
-          if (!this.arrayOfTweets.includes(e.text)) {
-            this.arrayOfTweets.push(e.text)
+          const tweetText = unescape(e.text)
+          if (!this.arrayOfTweets.includes(tweetText)) {
+            this.arrayOfTweets.push(unescape(tweetText))
           }
           if (i === a.length - 1) {
             lastID = e.id

--- a/index.js
+++ b/index.js
@@ -120,7 +120,7 @@ class TwitterBot {
         timeline.forEach((e, i, a) => {
           const tweetText = unescape(e.text)
           if (!this.arrayOfTweets.includes(tweetText)) {
-            this.arrayOfTweets.push(unescape(tweetText))
+            this.arrayOfTweets.push(tweetText)
           }
           if (i === a.length - 1) {
             lastID = e.id

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "homepage": "https://github.com/maximumdata/markov-twitter-bot#readme",
   "dependencies": {
+    "lodash.unescape": "^4.0.1",
     "markov-generator": "^1.0.8",
     "node-schedule": "^1.2.0",
     "this-is-probably-ok-to-say": "^1.0.100",


### PR DESCRIPTION
This patch for #1 uses lodash's [unescape](https://lodash.com/docs/4.17.2#unescape) which will unescape `&amp;`, `&lt;`, `&gt;`, `&quot;`, and `&#39;`. 